### PR TITLE
Potential fix for code scanning alert no. 1: Disabling certificate validation

### DIFF
--- a/api/ssl.js
+++ b/api/ssl.js
@@ -8,7 +8,7 @@ const sslHandler = async (urlString) => {
       host: parsedUrl.hostname,
       port: parsedUrl.port || 443,
       servername: parsedUrl.hostname,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
     };
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Potential fix for [https://github.com/0hmware/web-check/security/code-scanning/1](https://github.com/0hmware/web-check/security/code-scanning/1)

To fix the problem, the `rejectUnauthorized` option should be set to its secure default (`true`), or simply omitted from the options object, as `true` is the default value. This ensures that the TLS connection will only be established if the server presents a valid certificate signed by a trusted authority. The change should be made in the `options` object on line 11 of `api/ssl.js`. No additional imports or code changes are required, as the rest of the code already handles errors appropriately if the connection is not authorized.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
