### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/credits.yml
+++ b/.github/workflows/credits.yml
@@ -1,5 +1,7 @@
 # Inserts list of community members into ./README.md
 name: 💓 Inserts Contributors & Sponsors
+permissions:
+  contents: write
 on:
   workflow_dispatch: # Manual dispatch
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/0hmware/web-check/security/code-scanning/10](https://github.com/0hmware/web-check/security/code-scanning/10)

To fix the problem, you should add a `permissions` block to the workflow, either at the root level (to apply to all jobs) or at the job level (to customize per job). Since both jobs update the README file, they require `contents: write` permission. No other permissions appear necessary. The best fix is to add a `permissions` block at the root of the workflow, immediately after the `name` field, specifying `contents: write`. This will ensure that the jobs have only the minimum required permissions to update the README file, adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
